### PR TITLE
saphana: Add rhel8-saphana-tiny

### DIFF
--- a/templates/saphana/README.md
+++ b/templates/saphana/README.md
@@ -1,0 +1,16 @@
+# Overview
+
+This directory provides template, which could be used to run workloads like SAP
+HANA on Red Hat OpenShift Virtualization or kubevirt.
+
+
+# Usage
+
+The provided template can be used to create a Virtual Machine:
+
+`$ oc process --local -f templates/saphana/rhel8.saphana.yaml`
+
+If the template should be available in the graphical UI, it has to be deployed into a custom namespace:
+
+`$ oc create -n default -f templates/saphana/rhel8.saphana.yaml`
+

--- a/templates/saphana/rhel8.saphana.yaml
+++ b/templates/saphana/rhel8.saphana.yaml
@@ -1,0 +1,204 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  annotations:
+    defaults.template.kubevirt.io/disk: rootdisk
+    description: Template for Red Hat Enterprise Linux 8.4 for SAP HANA workloads. Please consult the SAP HANA guide for node setup requirements.
+    iconClass: icon-rhel
+    name.os.template.kubevirt.io/rhel8.4: Red Hat Enterprise Linux 8.0 or higher
+    openshift.io/display-name: Red Hat Enterprise Linux 8.4 VM for SAP HANA workloads
+    openshift.io/documentation-url: https://github.com/RHsyseng/cnv-supplemental-templates/templates/saphana/README.md
+    openshift.io/provider-display-name: Red Hat - Tech Preview
+    openshift.io/support-url: https://github.com/RHsyseng/cnv-supplemental-templates/issues
+    tags: hidden,kubevirt,virtualmachine,linux,rhel,sap,hana
+    template.kubevirt.io/provider: Red Hat - Tech Preview
+    template.kubevirt.io/provider-support-level: Experimental
+    template.kubevirt.io/provider-url: https://www.redhat.com
+    template.openshift.io/bindable: "false"
+  labels:
+    app.kubernetes.io/component: templating
+    flavor.template.kubevirt.io/tiny: "true"
+    os.template.kubevirt.io/rhel8.4: "true"
+    template.kubevirt.io/type: base
+    workload.template.kubevirt.io/saphana: "true"
+  name: rhel8-saphana-tiny
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+           {
+             "name": "minimal-required-memory",
+             "path": "jsonpath::.spec.domain.resources.requests.memory",
+             "rule": "integer",
+             "message": "This VM requires more memory.",
+             "min": 1610612736
+           }
+        ]
+    labels:
+      app: ${NAME}
+      vm.kubevirt.io/template: rhel8-saphana-tiny
+    name: ${NAME}
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        source:
+          registry:
+            pullMethod: node
+            url: ${SRC_CONTAINERDISK}
+        storage:
+          resources:
+            requests:
+              storage: 50Gi
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/flavor: tiny
+          vm.kubevirt.io/os: rhel8
+          vm.kubevirt.io/workload: saphana
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: tiny
+      spec:
+        domain:
+          cpu:
+            cores: ${{CPU_CORES}}
+            dedicatedCpuPlacement: true
+            features:
+            - name: invtsc
+              policy: require
+            isolateEmulatorThread: true
+            model: host-passthrough
+            numa:
+              guestMappingPassthrough: {}
+            sockets: ${{CPU_SOCKETS}}
+            threads: ${{CPU_THREADS}}
+          devices:
+            blockMultiQueue: true
+            disks:
+            - dedicatedIOThread: true
+              disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            - disk:
+                bus: virtio
+              name: downwardmetrics
+            interfaces:
+            - masquerade: {}
+              model: virtio
+              name: default
+            - name: sriov-net1
+              sriov: {}
+            - name: sriov-net2
+              sriov: {}
+            - name: sriov-net3
+              sriov: {}
+            networkInterfaceMultiqueue: true
+          ioThreadsPolicy: auto
+          machine:
+            type: pc-q35-rhel8.4.0
+          memory:
+            guest: ${MEMORY}
+            hugepages:
+              pageSize: ${HUGEPAGES_PAGE_SIZE}
+          resources:
+            requests:
+              memory: ${MEMORY_OVERHEAD}
+        hostname: ${NAME}
+        networks:
+        - name: default
+          pod: {}
+        - multus:
+            networkName: ${SRIOV_NETWORK_NAME1}
+          name: sriov-net1
+        - multus:
+            networkName: ${SRIOV_NETWORK_NAME2}
+          name: sriov-net2
+        - multus:
+            networkName: ${SRIOV_NETWORK_NAME3}
+          name: sriov-net3
+        nodeSelector:
+          kubevirt.io/workload: ${WORKLOAD_NODE_LABEL_VALUE}
+        terminationGracePeriodSeconds: 3600
+        tolerations:
+        - effect: NoSchedule
+          key: kubevirt.io/workload
+          operator: Equal
+          value: hana
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: cloud-user
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+        - downwardMetrics: {}
+          name: downwardmetrics
+parameters:
+- description: Name for the new VM
+  displayName: Name
+  name: NAME
+  required: true
+- description: Value of the node label selector key
+  displayName: The value of the kubevirt.io/workload node selector label key. The target node needs to match this label
+  name: WORKLOAD_NODE_LABEL_VALUE
+  required: true
+- description: Amount of memory
+  displayName: Memory
+  name: MEMORY
+  value: 24Gi
+- description: Amount of memory overhead for qemu
+  displayName: Memory Overhead
+  name: MEMORY_OVERHEAD
+  value: 44Gi
+- description: Amount of cores
+  displayName: CPU Cores
+  name: CPU_CORES
+  value: "4"
+- description: Amount of threads
+  displayName: CPU Threads
+  name: CPU_THREADS
+  value: "1"
+- description: Amount of sockets
+  displayName: CPU Sockets
+  name: CPU_SOCKETS
+  value: "1"
+- description: Name of the SR-IOV network1
+  displayName: SR-IOV network1
+  name: SRIOV_NETWORK_NAME1
+  required: true
+- description: Name of the SR-IOV network2
+  displayName: SR-IOV network2
+  name: SRIOV_NETWORK_NAME2
+  required: true
+- description: Name of the SR-IOV network3
+  displayName: SR-IOV network3
+  name: SRIOV_NETWORK_NAME3
+  required: true
+- description: Page size of huge pages
+  displayName: Huge page size
+  name: HUGEPAGES_PAGE_SIZE
+  value: 1Gi
+- description: Name of the source container disk to import
+  displayName: Source container disk
+  name: SRC_CONTAINERDISK
+  value: docker://registry.redhat.io/rhel8/rhel-guest-image:8.4.0
+- description: Randomized password for the cloud-init user cloud-user
+  displayName: Cloud user password
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD


### PR DESCRIPTION
The template "rhel8-saphana-tiny" is added.
Previously, this template was located in
https://github.com/kubevirt/common-templates .

This template was extracted by `oc get templates --namespace=openshift -o=yaml rhel8-saphana-tiny`

https://bugzilla.redhat.com/show_bug.cgi?id=2074384