### PR TITLE
saphana: Enable workaround for rhbz 2048556

### DIFF
--- a/templates/saphana/rhel8.saphana.yaml
+++ b/templates/saphana/rhel8.saphana.yaml
@@ -104,7 +104,8 @@ objects:
               sriov: {}
             - name: sriov-net3
               sriov: {}
-            networkInterfaceMultiqueue: true
+            # Workaround for https://bugzilla.redhat.com/2048556
+            # networkInterfaceMultiqueue: true
           ioThreadsPolicy: auto
           machine:
             type: pc-q35-rhel8.4.0


### PR DESCRIPTION
networkInterfaceMultiqueue enabled might result in an
not deterministic order of the virtual NICs.
This is tracked in https://bugzilla.redhat.com/2048556 .
networkInterfaceMultiqueue is relevant only for virtual NICs
connected by the virtio bus, but not for the SR-IOV virtual NICs.

Signed-off-by: Dominik Holler <dholler@redhat.com>