### PR TITLE
pc-i440fx: use storage api

### DIFF
--- a/templates/pc-i440fx/generic-server-large-pc-i440fx.yaml
+++ b/templates/pc-i440fx/generic-server-large-pc-i440fx.yaml
@@ -52,9 +52,7 @@ objects:
       metadata:
         name: ${NAME}
       spec:
-        pvc:
-          accessModes:
-            - ReadWriteMany
+        storage:
           resources:
             requests:
               storage: 30Gi


### PR DESCRIPTION
Use the superior API to specify the storage request. This does not require to specify the accessmode anymore.